### PR TITLE
Chapter 10: Fix VCR example

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     ffi (1.9.18)
-    geocoder (1.4.4)
+    geocoder (1.4.9)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashdiff (0.3.4)

--- a/spec/cassettes/User/performs_geocoding.yml
+++ b/spec/cassettes/User/performs_geocoding.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://freegeoip.io/json/161.185.207.20
+    uri: http://ipinfo.io/161.185.207.20/geo
     body:
       encoding: US-ASCII
       string: ''
@@ -18,28 +18,35 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Server:
-      - nginx/1.11.8
       Date:
-      - Thu, 07 Sep 2017 22:24:35 GMT
+      - Wed, 11 Jul 2018 04:46:59 GMT
       Content-Type:
-      - application/json
-      Content-Length:
-      - '244'
-      Connection:
-      - keep-alive
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Vary:
-      - Origin
-      X-Database-Date:
-      - Thu, 07 Sep 2017 09:08:50 GMT
-      Strict-Transport-Security:
-      - max-age=31536000
+      - Accept-Encoding
+      X-Powered-By:
+      - Express
+      X-Cloud-Trace-Context:
+      - 72c73f8f3c50820effc90c4aabb84d58/8793541516014538142;o=0
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 google
     body:
-      encoding: UTF-8
-      string: '{"ip":"161.185.207.20","country_code":"US","country_name":"United States","region_code":"NY","region_name":"New
-        York","city":"Brooklyn","zip_code":"11201","time_zone":"America/New_York","latitude":40.6944,"longitude":-73.9906,"metro_code":501}
-
-'
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "ip": "161.185.207.20",
+          "city": "Brooklyn",
+          "region": "New York",
+          "country": "US",
+          "loc": "40.6944,-73.9906",
+          "postal": "11201"
+        }
     http_version: 
-  recorded_at: Thu, 07 Sep 2017 22:24:42 GMT
+  recorded_at: Wed, 11 Jul 2018 04:46:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,6 +38,6 @@ RSpec.describe User, type: :model do
       user.geocode
     }.to change(user, :location).
       from(nil).
-      to("Brooklyn, New York, United States")
+      to("Brooklyn, New York, US")
   end
 end


### PR DESCRIPTION
If you attempted to run the tests added in chapter 10 since July 1, 2018, you may have noticed that the example using VCR to record an interaction with an external HTTP service no longer works. The IP geocoding service in use before, freegeoip, has been discontinued, and the geocoder gem now defaults to IPInfo.io. Thanks to @JunichiIto for pointing this out to me in #84 

This pull request contains code changes necessary to fix this issue, so you can continue to work through examples in the book. I've provided the steps in two standalone commits:

1. Update the geocoder gem to the latest version, so it uses IPInfo.io by default, and you don't need to do any extra configuration in the sample app. This applies to chapter 2 in the book, where we first look at the untested application.
2. Re-record the the VCR cassette for the sample code, then adjust the geocoding-related spec to reflect a difference in the new IP geocoding service's output. Again, this applies to chapter 10.

Please click through the commits for additional commentary and to see what's changed from the current book version to now.